### PR TITLE
Changed method to transformRingToRightHandedCSKeepAllCoords in validSurfaceOrientation test.

### DIFF
--- a/src/main/java/org/opengis/cite/iso19136/data/spatial/GeometryAssert.java
+++ b/src/main/java/org/opengis/cite/iso19136/data/spatial/GeometryAssert.java
@@ -404,7 +404,7 @@ public class GeometryAssert {
                 throw new RuntimeException(je);
             }
             // JTS algorithm assumes right-handed coordinates (e.g. lon,lat)
-            Coordinate[] exteriorCoords = GeodesyUtils.transformRingToRightHandedCS(gmlRing);
+            Coordinate[] exteriorCoords = GeodesyUtils.transformRingToRightHandedCSKeepAllCoords(gmlRing);
             Assert.assertTrue(CGAlgorithms.isCCW(exteriorCoords), ErrorMessage
                     .format(ErrorMessageKeys.EXT_BOUNDARY_ORIENT, surfaceElem.getAttributeNS(GML32.NS_NAME, "id")));
         }
@@ -419,7 +419,7 @@ public class GeometryAssert {
             } catch (JAXBException je) {
                 throw new RuntimeException(je);
             }
-            Coordinate[] interiorCoords = GeodesyUtils.transformRingToRightHandedCS(gmlRing);
+            Coordinate[] interiorCoords = GeodesyUtils.transformRingToRightHandedCSKeepAllCoords(gmlRing);
             Assert.assertFalse(CGAlgorithms.isCCW(interiorCoords), ErrorMessage.format(
                     ErrorMessageKeys.INT_BOUNDARY_ORIENT, surfaceElem.getAttributeNS(GML32.NS_NAME, "id"), j + 1));
         }


### PR DESCRIPTION
Fixed #26.

Before merging this PR, the following changes should be done:
  1. Release of the geomatic-geotk project as the new method added in GeodesyUtils class.
  2. The release version of the geomatic-geotk should be updated in current PR.

This PR is dependent on https://github.com/opengeospatial/geomatics-geotk/pull/2.